### PR TITLE
Update the latest CollectSamErrorMetrics.wdl from TAG to TAG-public

### DIFF
--- a/wdl/CollectSamErrorMetrics.wdl
+++ b/wdl/CollectSamErrorMetrics.wdl
@@ -1,21 +1,21 @@
 version 1.0
 
 workflow CollectSamErrorMetrics {
-	input {
-		File input_bam
+    input {
+        File input_bam
         File vcf_file
         File vcf_index_file
         File ref_fasta
         File ref_fai
         File ref_dict
         File intervals
-		String output_name
-		String picard_docker = "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.1-1540490856"
-	}
+        String output_name
+        String picard_docker = "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.1-1540490856"
+    }
 
-	call CollectSamErrorMetricsTask{
-		input:
-			input_bam = input_bam,
+    call CollectSamErrorMetricsTask {
+        input:
+            input_bam = input_bam,
             picard_docker=picard_docker,
             vcf_file=vcf_file,
             vcf_index_file=vcf_index_file,
@@ -23,44 +23,45 @@ workflow CollectSamErrorMetrics {
             ref_fai=ref_fai,
             ref_dict=ref_dict,
             intervals=intervals,
-			output_name = output_name
-	}
-	output{
-		Array[File] output_file = CollectSamErrorMetricsTask.output_metrics
-	}
+            output_name = output_name
+    }
+    output {
+        Array[File] output_file = CollectSamErrorMetricsTask.output_metrics
+    }
 }
 
 task CollectSamErrorMetricsTask {
-	input {
-		String output_name
-		String picard_docker
-		File input_bam
+    input {
+        String output_name
+        String picard_docker
+        File input_bam
         File ref_fasta
         File ref_fai
         File ref_dict
         File vcf_file
         File vcf_index_file
         File intervals
-		Int disk_gb = 400
-		Int memory_gb = 16
-	}
-	command {
-    java -Xms2000m -jar /usr/gitc/picard.jar CollectSamErrorMetrics I=~{input_bam} \
-      O=~{output_name} R=~{ref_fasta} V=~{vcf_file} L=~{intervals} \
-      ERROR_METRICS=null \
-      ERROR_METRICS="ERROR:INSERT_LENGTH" \
-      ERROR_METRICS="ERROR:CYCLE" \
-      ERROR_METRICS="ERROR:GC_CONTENT" \
-      ERROR_METRICS="ERROR" 
+        Int disk_gb = 400
+        Int memory_gb = 16
+    }
+    command {
+        java -Xms2000m -jar /usr/gitc/picard.jar CollectSamErrorMetrics I=~{input_bam} \
+        O=~{output_name} R=~{ref_fasta} V=~{vcf_file} L=~{intervals} \
+        ERROR_METRICS=null \
+        ERROR_METRICS="ERROR:INSERT_LENGTH" \
+        ERROR_METRICS="ERROR:CYCLE" \
+        ERROR_METRICS="ERROR:GC_CONTENT" \
+        ERROR_METRICS="ERROR"
 
-	}
-	output {
-		Array[File] output_metrics = glob("~{output_name}*")
-	}
-	runtime {
-		docker: picard_docker
-		disks: "local-disk " + disk_gb + " HDD"
-		memory: memory_gb + "GB"
-		cpu: "1"
-	}
+    }
+    output {
+        Array[File] output_metrics = glob("~{output_name}*")
+    }
+    runtime {
+        docker: picard_docker
+        disks: "local-disk " + disk_gb + " HDD"
+        memory: memory_gb + "GB"
+        cpu: "1"
+    }
 }
+


### PR DESCRIPTION
I am working on one ticket requires running GATK CollectSamErrorMetrics. I initially imported `CollectSamErrorMetrics.wdl` from [dockstore](https://dockstore.org/workflows/github.com/broadinstitute/TAG-public/CollectSamErrorMetrics:master?tab=info). I realize it is not update to date as what we have in `TAG/Master_WDLs`. So, I copied the latest CollectSamErrorMetrics wdl script from TAG to TAG-public. This will help us to make sure our dockstore CollectSamErrorMetrics.wdl is up to date. 