### PR TITLE
set reference_genome==hg19 by default and omit --sites argument when true

### DIFF
--- a/PeddyAnalysis/PeddyAnalysis.wdl
+++ b/PeddyAnalysis/PeddyAnalysis.wdl
@@ -606,13 +606,13 @@ task RunPeddy {
         File merged_gvcf
         File merged_gvcf_index
         File fam_file
-        String reference_genome = "hg38"
+        String? reference_genome
         Int memory = 16
         Int disk_size = 16
         String? docker_override
     }
     command <<<        
-        peddy -p 4 --plot --prefix ~{prefix} ~{merged_gvcf} ~{fam_file} --sites ~{reference_genome}
+        peddy -p 4 --plot --prefix ~{prefix} ~{merged_gvcf} ~{fam_file}  ~{if defined(reference_genome) then "--sites " + reference_genome else ""}
 
     >>>
     output {


### PR DESCRIPTION
This is to deal with the hg19 data we recently get from fabric. 

So Peddy will not accept --sites hg19 args in the command line, we should either not specify --sites which by fault it will use hg19, or we should use --sites hg38.

Use this command line to handle optional reference_genome input.

`~{if defined(reference_genome) then "--sites " + reference_genome else ""}`


