### PR TITLE
Trailing comma in c() is not valid R

### DIFF
--- a/iChor/iChorCNA_hg38/iChorCNA_hg38.inputs.json
+++ b/iChor/iChorCNA_hg38/iChorCNA_hg38.inputs.json
@@ -5,7 +5,7 @@
     "ichorCNA.centromere": "gs://gptag/ichorCNA_resources/GRCh38.GCA_000001405.2_centromere_acen.txt",
     "ichorCNA.chrTrain": "paste0('chr', c(1:18,20:22))",
     "ichorCNA.chr_counter": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY",
-    "ichorCNA.chrs": "paste0('chr', c(1:22,))",
+    "ichorCNA.chrs": "paste0('chr', c(1:22))",
     "ichorCNA.gcWig": "gs://gptag/ichorCNA_resources/gc_hg38_1000kb.wig",
     "ichorCNA.genomeBuild": "hg38",
     "ichorCNA.genome_style": "UCSC",


### PR DESCRIPTION
This came up when testing ichor in ops controller